### PR TITLE
Only one var statement per function scope

### DIFF
--- a/date.js
+++ b/date.js
@@ -436,15 +436,16 @@ Date.fullYearStart = '20';
 	 */
 	Date.fromString = function(s, format)
 	{
-		var f = format || Date.format;
-		var d = new Date('01/01/1977');
-		
-		var mLength = 0;
+		var f = format || Date.format,
+		    d = new Date('01/01/1977'),
+		    mLength = 0,
+		    iM, iD, iY,
+		    i, mStr;
 
-		var iM = f.indexOf('mmmm');
+		iM = f.indexOf('mmmm');
 		if (iM > -1) {
-			for (var i=0; i<Date.monthNames.length; i++) {
-				var mStr = s.substr(iM, Date.monthNames[i].length);
+			for (i=0; i<Date.monthNames.length; i++) {
+				mStr = s.substr(iM, Date.monthNames[i].length);
 				if (Date.monthNames[i] == mStr) {
 					mLength = Date.monthNames[i].length - 4;
 					break;
@@ -454,8 +455,8 @@ Date.fullYearStart = '20';
 		} else {
 			iM = f.indexOf('mmm');
 			if (iM > -1) {
-				var mStr = s.substr(iM, 3);
-				for (var i=0; i<Date.abbrMonthNames.length; i++) {
+				mStr = s.substr(iM, 3);
+				for (i=0; i<Date.abbrMonthNames.length; i++) {
 					if (Date.abbrMonthNames[i] == mStr) break;
 				}
 				d.setMonth(i);
@@ -464,7 +465,7 @@ Date.fullYearStart = '20';
 			}
 		}
 		
-		var iY = f.indexOf('yyyy');
+		iY = f.indexOf('yyyy');
 
 		if (iY > -1) {
 			if (iM < iY)
@@ -480,7 +481,7 @@ Date.fullYearStart = '20';
 			// TODO - this doesn't work very well - are there any rules for what is meant by a two digit year?
 			d.setFullYear(Number(Date.fullYearStart + s.substr(f.indexOf('yy'), 2)));
 		}
-		var iD = f.indexOf('dd');
+		iD = f.indexOf('dd');
 		if (iM < iD)
 		{
 			iD += mLength;


### PR DESCRIPTION
I use `date.js` as part of a larger project which is later monified using YUI Compressor 2.4.7. When warnings are enabled, YUI Compressor reports several lines in which the `var` statement is repeated within the same function scope.

The command used to replicate warnings:

```
$ java -jar yuicompressor-2.4.7.jar --type=js --verbose date.js
```

The warnings given:

```
[WARNING] Try to use a single 'var' statement per scope.
var f=format||Date.format; ---> var  <--- d=new Date("01/01/1977");var mLength

[WARNING] Try to use a single 'var' statement per scope.
var d=new Date("01/01/1977"); ---> var  <--- mLength=0;var iM=f.indexOf

[WARNING] Try to use a single 'var' statement per scope.
("01/01/1977");var mLength=0; ---> var  <--- iM=f.indexOf("mmmm");if

[WARNING] Try to use a single 'var' statement per scope.
(iM>-1){for( ---> var  <--- i=0;i<Date.monthNames.

[WARNING] Try to use a single 'var' statement per scope.
.monthNames.length;i++){ ---> var  <--- mStr=s.substr(iM,Date.

[WARNING] Try to use a single 'var' statement per scope.
;if(iM>-1){ ---> var  <--- mStr=s.substr(iM,3)

[WARNING] The variable mStr has already been declared in the same scope...
if(iM>-1){var  ---> mStr <--- =s.substr(iM,3);

[WARNING] Try to use a single 'var' statement per scope.
substr(iM,3);for( ---> var  <--- i=0;i<Date.abbrMonthNames.

[WARNING] The variable i has already been declared in the same scope...
(iM,3);for(var  ---> i <--- =0;i<Date.abbrMonthNames.length

[WARNING] Try to use a single 'var' statement per scope.
2))-1);}} ---> var  <--- iY=f.indexOf("yyyy");if

[WARNING] Try to use a single 'var' statement per scope.
"yy"),2)));} ---> var  <--- iD=f.indexOf("dd");if
```

This isn't a critical change and it doesn't change the behavior of the script but makes YUI Compressor happy.
