### PR TITLE
Added format string to asString

### DIFF
--- a/date.js
+++ b/date.js
@@ -412,13 +412,13 @@ Date.fullYearStart = '20';
 		return r
 			.split('yyyy').join(this.getFullYear())
 			.split('yy').join((this.getFullYear() + '').substring(2))
+			.split('dd').join(_zeroPad(this.getDate()))
 			.split('d').join(this.getDate())
 			.split('DD').join(this.getDayName(false))
 			.split('D').join(this.getDayName(true))
 			.split('mmmm').join(this.getMonthName(false))
 			.split('mmm').join(this.getMonthName(true))
 			.split('mm').join(_zeroPad(this.getMonth()+1))
-			.split('dd').join(_zeroPad(this.getDate()))
 			.split('hh').join(_zeroPad(this.getHours()))
 			.split('min').join(_zeroPad(this.getMinutes()))
 			.split('ss').join(_zeroPad(this.getSeconds()));


### PR DESCRIPTION
I'm using date.js to replace jQuery UI datepickers formatDate method, and day names and non-zero date were missing. I added them as 'DD' for full day name, 'D' for abbr day name, 'd' for non-zero date. I adjusted the order so these we done first to avoid them being interpreted after a month name replacement earlier on.
